### PR TITLE
MAINT: q2studio prototype status warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,8 +110,13 @@
         <div class="col-md-8">
           <h4>
             <a href="https://docs.qiime2.org/2017.10/interfaces/q2studio/">q2studio</a>
-            <small>the graphical user interface</small>
+            <small>the graphical user interface (PROTOTYPE)</small>
           </h4>
+          <div class="alert alert-warning">
+            q2studio is a functional prototype of a graphical user interface
+            for QIIME 2, and is not necessarily feature-complete with respect
+            to q2cli and the Artifact API.
+          </div>
           <img class="img-responsive center-block interface" src="./assets/img/q2studio.png">
         </div>
       </div>


### PR DESCRIPTION
Fixes #49 

![screenshot_20171118_122627](https://user-images.githubusercontent.com/274668/32984058-fa0052f6-cc5b-11e7-8b23-b56ea53cb3ff.png)

I experimented with watermarking the studio screenshot, but my attempts all looked too busy.