### PR TITLE
Added link to code of conduct page

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,9 +53,9 @@
             that is extensible, free, open source, and <a href="https://github.com/orgs/qiime2/people" target="_blank">community developed.</a>
           </p>
           <p>
-            <a class="btn btn-primary btn-lg" href="https://docs.qiime2.org" role="button">Learn more &raquo;</a>
-            <a class="btn btn-success btn-lg" href="#citing" role="button">Citing QIIME 2 &raquo;</a>
             <a class="btn btn-info btn-lg" href="https://forum.qiime2.org/t/qiime-2-community-code-of-conduct/9057" role="button">Code of Conduct &raquo;</a>
+            <a class="btn btn-success btn-lg" href="#citing" role="button">Citing QIIME 2 &raquo;</a>
+            <a class="btn btn-primary btn-lg" href="https://docs.qiime2.org" role="button">Learn more &raquo;</a>
           </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
           <p>
             <a class="btn btn-primary btn-lg" href="https://docs.qiime2.org" role="button">Learn more &raquo;</a>
             <a class="btn btn-success btn-lg" href="#citing" role="button">Citing QIIME 2 &raquo;</a>
+            <a class="btn btn-info btn-lg" href="https://forum.qiime2.org/t/qiime-2-community-code-of-conduct/9057" role="button">Code of Conduct &raquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
I added a link to the code of conduct for this page. I have inserted the linking button inside the jumbotron of the page. This may be too prominent in terms of placement, but it certainly sticks out.

See issue #68 for more details

Fixes #68

Snapshot of the page:
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/30784905/71124432-117c5180-21a2-11ea-8801-a0fba2c936c1.png">

