### PR TITLE
rm: removing q2studio blurb/img

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,18 +112,6 @@
             </div>
           </div>
         </div>
-        <div class="col-md-8">
-          <h4>
-            <a href="https://docs.qiime2.org/2022.8/interfaces/q2studio/">q2studio</a>
-            <small>the graphical user interface (PROTOTYPE)</small>
-          </h4>
-          <div class="alert alert-warning">
-            q2studio is a functional prototype of a graphical user interface
-            for QIIME 2, and is not necessarily feature-complete with respect
-            to q2cli and the Artifact API.
-          </div>
-          <img class="img-responsive center-block interface" src="./assets/img/q2studio.png">
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
This PR removes the blurb/image of q2studio from our website home page. Preview of changes can be seen below:

![Screen Shot 2022-11-22 at 10 50 49 AM](https://user-images.githubusercontent.com/54517601/203386036-425e4ca2-4f5b-46ad-8333-058680e0ec9b.png)

The blank segment on the right side of the page should be replaced with a blurb/images of q2galaxy.