### PR TITLE
Add missing q2galaxy link

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
         </div>
         <div class="col-md-8">
           <h4>
-            <a>q2galaxy</a>
+            <a href="https://github.com/qiime2/q2galaxy/">q2galaxy</a>
             <small>the graphical user interface</small>
           </h4>
           <img class="img-responsive center-block interface" src="./assets/img/q2galaxy.png">


### PR DESCRIPTION
The q2galaxy entry with enticing image was missing a URL.

https://github.com/qiime2/q2galaxy seems the only choice, there is currently no documentation page that I could see.